### PR TITLE
New docstrings on readthedocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ coverage.xml
 *.log
 
 # Sphinx documentation
-docs/_build/
+doc/_build/
 
 # PyBuilder
 target/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/LSSTDESC/pserv.svg?branch=master)](https://travis-ci.org/LSSTDESC/pserv)
 [![Coverage Status](https://coveralls.io/repos/github/LSSTDESC/pserv/badge.svg?branch=master)](https://coveralls.io/github/LSSTDESC/pserv?branch=master)
+[![Documentation Status](http://readthedocs.org/projects/pserv/badge/?version=latest)](http://pserv.readthedocs.io/en/latest/?badge=latest)
 
 This is a package of scripts to set up, maintain, and provide interfaces to a
 very simple "preliminary" or "practice" database which serves LSST data resulting from
@@ -16,6 +17,9 @@ database implementation with a "MySQL-like" DBMS.  Since
 `Pserv` is meant to emulate `Qserv` but on a single node, a MySQL
 database is used. `Pserv` allows you to start designing and testing
 queries on LSST catalogs while `Qserv` is still being developed.
+
+`Pserv` API documentation is available at [pserv.readthedocs.io](http://pserv.readthedocs.io/)
+
 
 ## People
 * [Jim Chiang](https://github.com/DarkEnergyScienceCollaboration/pserv/issues/new?body=@jchiang87) (SLAC)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,178 @@
+# Makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+PAPER         =
+BUILDDIR      = _build
+
+# User-friendly check for sphinx-build
+ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+endif
+
+# Internal variables.
+PAPEROPT_a4     = -D latex_paper_size=a4
+PAPEROPT_letter = -D latex_paper_size=letter
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+# the i18n builder cannot share the environment and doctrees with the others
+I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  html       to make standalone HTML files"
+	@echo "  dirhtml    to make HTML files named index.html in directories"
+	@echo "  singlehtml to make a single large HTML file"
+	@echo "  pickle     to make pickle files"
+	@echo "  json       to make JSON files"
+	@echo "  htmlhelp   to make HTML files and a HTML help project"
+	@echo "  qthelp     to make HTML files and a qthelp project"
+	@echo "  devhelp    to make HTML files and a Devhelp project"
+	@echo "  epub       to make an epub"
+	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
+	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
+	@echo "  latexpdfja to make LaTeX files and run them through platex/dvipdfmx"
+	@echo "  text       to make text files"
+	@echo "  man        to make manual pages"
+	@echo "  texinfo    to make Texinfo files"
+	@echo "  info       to make Texinfo files and run them through makeinfo"
+	@echo "  gettext    to make PO message catalogs"
+	@echo "  changes    to make an overview of all changed/added/deprecated items"
+	@echo "  xml        to make Docutils-native XML files"
+	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
+	@echo "  linkcheck  to check all external links for integrity"
+	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+
+clean:
+	rm -rf $(BUILDDIR)/*
+	rm -rf api/*
+
+html:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+dirhtml:
+	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+singlehtml:
+	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
+	@echo
+	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
+
+pickle:
+	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
+	@echo
+	@echo "Build finished; now you can process the pickle files."
+
+json:
+	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
+	@echo
+	@echo "Build finished; now you can process the JSON files."
+
+htmlhelp:
+	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
+	@echo
+	@echo "Build finished; now you can run HTML Help Workshop with the" \
+	      ".hhp project file in $(BUILDDIR)/htmlhelp."
+
+qthelp:
+	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
+	@echo
+	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
+	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/sep.qhcp"
+	@echo "To view the help file:"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/sep.qhc"
+
+devhelp:
+	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
+	@echo
+	@echo "Build finished."
+	@echo "To view the help file:"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/sep"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/sep"
+	@echo "# devhelp"
+
+epub:
+	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
+	@echo
+	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
+
+latex:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo
+	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
+	@echo "Run \`make' in that directory to run these through (pdf)latex" \
+	      "(use \`make latexpdf' here to do that automatically)."
+
+latexpdf:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo "Running LaTeX files through pdflatex..."
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf
+	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+
+latexpdfja:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo "Running LaTeX files through platex and dvipdfmx..."
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
+	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+
+text:
+	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
+	@echo
+	@echo "Build finished. The text files are in $(BUILDDIR)/text."
+
+man:
+	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
+	@echo
+	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
+
+texinfo:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	@echo
+	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
+	@echo "Run \`make' in that directory to run these through makeinfo" \
+	      "(use \`make info' here to do that automatically)."
+
+info:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	@echo "Running Texinfo files through makeinfo..."
+	make -C $(BUILDDIR)/texinfo info
+	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
+
+gettext:
+	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
+	@echo
+	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
+
+changes:
+	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
+	@echo
+	@echo "The overview file is in $(BUILDDIR)/changes."
+
+linkcheck:
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	@echo
+	@echo "Link check complete; look for any errors in the above output " \
+	      "or in $(BUILDDIR)/linkcheck/output.txt."
+
+doctest:
+	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
+	@echo "Testing of doctests in the sources finished, look at the " \
+	      "results in $(BUILDDIR)/doctest/output.txt."
+
+xml:
+	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
+	@echo
+	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
+
+pseudoxml:
+	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
+	@echo
+	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,7 +8,8 @@ sys.path.insert(0, os.path.abspath('../python/desc/pserv'))
 # http://stackoverflow.com/questions/15889621/sphinx-how-to-exclude-imports-in-automodule#15912502
 autodoc_mock_imports = ["lsst.daf.persistence", "astropy.time",
                         "astropy.io.fits", "lsst.afw.math",
-                        "lsst.utils", ".Pserv"]
+                        "lsst.utils", "Pserv",
+                        "Pserv.create_csv_file_from_fits"]
 
 # For reference, here's the current list of imports:
 # from __future__ import absolute_import, print_function
@@ -28,6 +29,7 @@ autodoc_mock_imports = ["lsst.daf.persistence", "astropy.time",
 # import sys
 # import lsst.afw.math as afwMath
 # import lsst.utils as lsstUtils
+# from .Pserv import create_csv_file_from_fits
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,40 @@
+import sys
+import os
+
+# Provide path to the python modules we want to run autodoc on
+sys.path.insert(0, os.path.abspath('../qp'))
+# Avoid imports that may be unsatisfied when running sphinx, see:
+# http://stackoverflow.com/questions/15889621/sphinx-how-to-exclude-imports-in-automodule#15912502
+autodoc_mock_imports = ["scipy","scipy.interpolate"]
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode']
+
+# on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:
+    # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+# otherwise, readthedocs.org uses their theme by default, so
+# no need to specify it.
+
+master_doc = 'index'
+autosummary_generate = True
+autoclass_content = "class"
+autodoc_default_flags = ["members", "no-special-members"]
+
+html_sidebars = { '**': ['globaltoc.html', 'relations.html', 'sourcelink.html', 'searchbox.html'], }
+
+project = u'pserv'
+author = u'Jim Chiang'
+copyright = u'2017, ' + author
+version = "0.1"
+release = "0.1.0"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,9 +3,31 @@ import os
 
 # Provide path to the python modules we want to run autodoc on
 sys.path.insert(0, os.path.abspath('../python/desc/pserv'))
+
 # Avoid imports that may be unsatisfied when running sphinx, see:
 # http://stackoverflow.com/questions/15889621/sphinx-how-to-exclude-imports-in-automodule#15912502
-autodoc_mock_imports = ["scipy","scipy.interpolate"]
+autodoc_mock_imports = ["lsst.daf.persistence", "astropy.time",
+                        "astropy.io.fits", "lsst.afw.math",
+                        "lsst.utils", ".Pserv"]
+
+# For reference, here's the current list of imports:
+# from __future__ import absolute_import, print_function
+# import copy
+# import csv
+# from collections import OrderedDict
+# import numpy as np
+# import pandas as pd
+# import astropy.io.fits as fits
+# import sqlalchemy
+# import lsst.daf.persistence as dp
+# import os
+# import sqlite3
+# import astropy.time
+# import pickle
+# import itertools
+# import sys
+# import lsst.afw.math as afwMath
+# import lsst.utils as lsstUtils
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,8 +8,7 @@ sys.path.insert(0, os.path.abspath('../python/desc/pserv'))
 # http://stackoverflow.com/questions/15889621/sphinx-how-to-exclude-imports-in-automodule#15912502
 autodoc_mock_imports = ["lsst.daf.persistence", "astropy.time",
                         "astropy.io.fits", "lsst.afw.math",
-                        "lsst.utils",
-                        "Pserv.create_csv_file_from_fits"]
+                        "lsst.utils"]
 
 # For reference, here's the current list of imports:
 # from __future__ import absolute_import, print_function

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,7 +2,7 @@ import sys
 import os
 
 # Provide path to the python modules we want to run autodoc on
-sys.path.insert(0, os.path.abspath('../qp'))
+sys.path.insert(0, os.path.abspath('../python/desc/pserv'))
 # Avoid imports that may be unsatisfied when running sphinx, see:
 # http://stackoverflow.com/questions/15889621/sphinx-how-to-exclude-imports-in-automodule#15912502
 autodoc_mock_imports = ["scipy","scipy.interpolate"]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath('../python/desc/pserv'))
 # http://stackoverflow.com/questions/15889621/sphinx-how-to-exclude-imports-in-automodule#15912502
 autodoc_mock_imports = ["lsst.daf.persistence", "astropy.time",
                         "astropy.io.fits", "lsst.afw.math",
-                        "lsst.utils", "Pserv",
+                        "lsst.utils",
                         "Pserv.create_csv_file_from_fits"]
 
 # For reference, here's the current list of imports:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,6 +22,6 @@ API Documentation
 =================
 
 
-.. automodule:: python/desc/pserv
+.. automodule:: pserv
     :members:
     :undoc-members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,7 +27,7 @@ Pserv
 The main ``PServ`` module contains classes for building a ``Pserv``
 mega-scale undistributed database: handling the connection to the
 ``mysql`` database, and transferring in data from files. If no
-documentation for the ``Pserv` functions appears below (and before the
+documentation for the ``Pserv`` functions appears below (and before the
 "Repository Info" section), it means that the Sphinx ``conf.py`` needs
 fixing to handle the various import statements better.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,5 @@
 ============================================
-Pserv : mega-scale non-distributed database
+Pserv : mega-scale undistributed database
 ============================================
 
 This is a package of scripts to set up, maintain, and provide interfaces to a
@@ -22,6 +22,6 @@ API Documentation
 =================
 
 
-.. automodule:: python/desc/pserv
+.. automodule:: Pserv
     :members:
     :undoc-members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,27 @@
+============================================
+Pserv : mega-scale non-distributed database
+============================================
+
+This is a package of scripts to set up, maintain, and provide interfaces to a
+very simple "preliminary" or "practice" database which serves LSST data resulting from
+running early versions of the Level 1 and Level 2 pipelines.  A
+subset of the tables using the LSST `baseline
+schema <https://lsst-web.ncsa.illinois.edu/schema/index.php?sVer=baseline>`_
+will be supported.
+
+The production LSST database will be implemented via
+```Qserv`` <https://github.com/lsst/qserv>`_, which is a distributed
+database implementation with a "MySQL-like" DBMS.  Since
+``Pserv`` is meant to emulate ``Qserv`` but on a single node, a MySQL
+database is used. ``Pserv`` allows you to start designing and testing
+queries on LSST catalogs while ``Qserv`` is still being developed.
+
+
+
+API Documentation
+=================
+
+
+.. automodule:: pserv
+    :members:
+    :undoc-members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,11 +24,11 @@ API Documentation
 Pserv
 -----
 
-The main `PServ` module contains classes for building a `Pserv`
+The main ``PServ`` module contains classes for building a ``Pserv``
 mega-scale undistributed database: handling the connection to the
-`mysql` database, and transferring in data from files. If no
-documentation for the `Pserv` functions appears below (and before the
-"Repository Info" section), it means that the Sphinx `conf.py` needs
+``mysql`` database, and transferring in data from files. If no
+documentation for the ``Pserv` functions appears below (and before the
+"Repository Info" section), it means that the Sphinx ``conf.py`` needs
 fixing to handle the various import statements better.
 
 .. automodule:: Pserv

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,7 +10,7 @@ schema <https://lsst-web.ncsa.illinois.edu/schema/index.php?sVer=baseline>`_
 will be supported.
 
 The production LSST database will be implemented via
-```Qserv`` <https://github.com/lsst/qserv>`_, which is a distributed
+`Qserv <https://github.com/lsst/qserv>`_, which is a distributed
 database implementation with a "MySQL-like" DBMS.  Since
 ``Pserv`` is meant to emulate ``Qserv`` but on a single node, a MySQL
 database is used. ``Pserv`` allows you to start designing and testing
@@ -22,6 +22,6 @@ API Documentation
 =================
 
 
-.. automodule:: pserv
+.. automodule:: python/desc/pserv
     :members:
     :undoc-members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,20 +21,44 @@ queries on LSST catalogs while ``Qserv`` is still being developed.
 API Documentation
 =================
 
+Pserv
+-----
+
+The main `PServ` module contains classes for building a `Pserv`
+mega-scale undistributed database: handling the connection to the
+`mysql` database, and transferring in data from files. If no
+documentation for the `Pserv` functions appears below (and before the
+"Repository Info" section), it means that the Sphinx `conf.py` needs
+fixing to handle the various import statements better.
 
 .. automodule:: Pserv
     :members:
     :undoc-members:
 
+
+Repository Info
+---------------
+
 .. automodule:: repository_info
     :members:
     :undoc-members:
+
+
+Registry Tools
+--------------
 
 .. automodule:: registry_tools
     :members:
     :undoc-members:
 
+
+Utilities
+---------
+
+If no documentation for the utility functions appears below it means
+that the Sphinx `conf.py` needs fixing to handle the various import
+statements better.
+
 .. automodule:: utils
     :members:
     :undoc-members:
-

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,3 +25,16 @@ API Documentation
 .. automodule:: Pserv
     :members:
     :undoc-members:
+
+.. automodule:: repository_info
+    :members:
+    :undoc-members:
+
+.. automodule:: registry_tools
+    :members:
+    :undoc-members:
+
+.. automodule:: utils
+    :members:
+    :undoc-members:
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,6 +22,6 @@ API Documentation
 =================
 
 
-.. automodule:: pserv
+.. automodule:: python/desc/pserv
     :members:
     :undoc-members:


### PR DESCRIPTION
@jchiang87 I have *almost* got the `Pserv` API documentation on the web at http://pserv.readthedocs.io/en/readthedocs/ - the `Pserv.py` and `utils.py` don't load, for some reason, and then I don't know how to handle the internal `from .Pserv import ...` command  (or whether I need to). Anyway, Happy Sunday to you - I thought your new docstrings deserved some web-attention :-)